### PR TITLE
Fix: npm run deploy is a no-op inside Cloudflare Pages build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "private": true,
   "scripts": {
     "dev": "wrangler pages dev public",
-    "deploy": "wrangler pages deploy public",
+    "deploy": "[ \"$CF_PAGES\" = \"1\" ] && echo 'CF Pages build — skipping wrangler deploy' || wrangler pages deploy public",
     "db:migrate": "wrangler d1 execute RESIST_DB --local --file=schema/schema.sql",
     "db:seed": "wrangler d1 execute RESIST_DB --local --file=seed/seed-camelot.sql",
     "db:reset": "rm -rf .wrangler && npm run db:migrate",
+    "db:seed:local": "wrangler d1 execute RESIST_DB --local --file=seed/seed-camelot-local.sql",
+    "db:reset:local": "rm -rf .wrangler && npm run db:migrate && npm run db:seed:local",
     "db:migrate:remote": "wrangler d1 execute RESIST_DB --remote --file=schema/schema.sql",
     "db:seed:remote": "wrangler d1 execute RESIST_DB --remote --file=seed/seed-camelot.sql"
   },


### PR DESCRIPTION
## Summary
- `npm run deploy` now detects the `CF_PAGES=1` env var that Cloudflare Pages injects into every build and exits cleanly instead of calling `wrangler pages deploy`
- This fixes the auth error (`code: 10000`) that occurred because the auto-injected build token doesn't have Pages deploy permissions
- Local deploys (`npm run deploy` on your machine) are unaffected

## Why this matters
Installers setting `npm run deploy` as the Cloudflare Pages build command will now get a successful build instead of an auth failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)