### PR TITLE
Fix setup wizard crash on production D1 (db.exec → db.batch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 dist/
 .DS_Store
 CLAUDE.md
+seed/seed-camelot-local.sql


### PR DESCRIPTION
## Summary

- Production D1's `db.exec()` throws `TypeError: Cannot read properties of undefined (reading 'duration')` when processing large multi-statement DDL strings on some runtime versions
- This error was caught by `setup.js`, returned as `data.error` in the HTTP 500 response, and displayed directly in the wizard UI — so users saw the raw D1 internal error instead of completing setup
- Replaced the single `db.exec(bigMultiStatementSQL)` call in `runMigrations()` with `db.batch([...])` using one `db.prepare()` per DDL statement, which works correctly on all D1 runtimes

## Test plan

- [ ] Wipe the remote D1 database so `app_mode` is unset
- [ ] Visit the production site and confirm the setup wizard appears
- [ ] Complete the wizard in Live Mode — should succeed without error
- [ ] Complete the wizard in Demo Mode — should succeed without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)